### PR TITLE
feat(test): added migration skipping flag

### DIFF
--- a/.github/workflows/test-integration-postgres-mongo-redis.yml
+++ b/.github/workflows/test-integration-postgres-mongo-redis.yml
@@ -12,6 +12,11 @@ on:
         default: 'npm run db:up'
         required: false
         type: string
+      skip_migration:
+        description: 'Whether or not the migrations should be skipped. Useful for when you want to run specific migration tests'
+        default: false
+        required: false
+        type: boolean
       test_command:
         description: 'The command to run the integration tests'
         default: 'npm run test:ci'
@@ -105,7 +110,8 @@ jobs:
         working-directory: 'repo'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.token }}
-      - run: ${{inputs.migration_command}}
+      - run: ${{ inputs.migration_command }}
+        if: ${{ !inputs.skip_migration }}
         working-directory: 'repo'
         env:
           ENVIRONMENT: test

--- a/.github/workflows/test-integration-postgres-mongo.yml
+++ b/.github/workflows/test-integration-postgres-mongo.yml
@@ -12,6 +12,11 @@ on:
         default: 'npm run db:up'
         required: false
         type: string
+      skip_migration:
+        description: 'Whether or not the migrations should be skipped. Useful for when you want to run specific migration tests'
+        default: false
+        required: false
+        type: boolean
       test_command:
         description: 'The command to run the integration tests'
         default: 'npm run test:ci'
@@ -96,7 +101,8 @@ jobs:
         working-directory: 'repo'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.token }}
-      - run: ${{inputs.migration_command}}
+      - run: ${{ inputs.migration_command }}
+        if: ${{ !inputs.skip_migration }}
         working-directory: 'repo'
         env:
           ENVIRONMENT: test

--- a/.github/workflows/test-integration-postgres.yml
+++ b/.github/workflows/test-integration-postgres.yml
@@ -12,6 +12,11 @@ on:
         default: 'npm run db:up'
         required: false
         type: string
+      skip_migration:
+        description: 'Whether or not the migrations should be skipped. Useful for when you want to run specific migration tests'
+        default: false
+        required: false
+        type: boolean
       test_command:
         description: 'The command to run the integration tests'
         default: 'npm run test:ci'
@@ -70,7 +75,8 @@ jobs:
         working-directory: 'repo'
         env:
           NODE_AUTH_TOKEN: ${{secrets.token}}
-      - run: ${{inputs.migration_command}}
+      - run: ${{ inputs.migration_command }}
+        if: ${{ !inputs.skip_migration }}
         working-directory: 'repo'
         env:
           ENVIRONMENT: test


### PR DESCRIPTION
Updated the Postgres integration workflows to allow for skipping the migrations for cases when a workflow may want to run tests specifically against a non-migrated db