### PR TITLE
fix: inputs.postgres_database

### DIFF
--- a/.github/workflows/test-integration-postgres-mongo-redis.yml
+++ b/.github/workflows/test-integration-postgres-mongo-redis.yml
@@ -42,6 +42,11 @@ on:
         default: 'localhost'
         required: false
         type: string
+      postgres_database:
+        description: 'The Postgres database'
+        default: 'openphone'
+        required: false
+        type: string
       mongo_version:
         description: 'The version of Mongo to use'
         default: '4.2'
@@ -73,6 +78,7 @@ jobs:
         env:
           POSTGRES_USER: ${{ inputs.postgres_user }}
           POSTGRES_PASSWORD: ${{ inputs.postgres_password }}
+          POSTGRES_DB: ${{ inputs.postgres_database }}
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/test-integration-postgres-mongo.yml
+++ b/.github/workflows/test-integration-postgres-mongo.yml
@@ -42,6 +42,11 @@ on:
         default: 'localhost'
         required: false
         type: string
+      postgres_database:
+        description: 'The Postgres database'
+        default: 'openphone'
+        required: false
+        type: string
       mongo_version:
         description: 'The version of Mongo to use'
         default: '4.2'
@@ -73,6 +78,7 @@ jobs:
         env:
           POSTGRES_USER: ${{ inputs.postgres_user }}
           POSTGRES_PASSWORD: ${{ inputs.postgres_password }}
+          POSTGRES_DB: ${{ inputs.postgres_database }}
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/test-integration-postgres.yml
+++ b/.github/workflows/test-integration-postgres.yml
@@ -42,6 +42,11 @@ on:
         default: 'localhost'
         required: false
         type: string
+      postgres_database:
+        description: 'The Postgres database'
+        default: 'openphone'
+        required: false
+        type: string
 
 jobs:
   test-integration-postgres:
@@ -53,6 +58,7 @@ jobs:
         env:
           POSTGRES_USER: ${{ inputs.postgres_user }}
           POSTGRES_PASSWORD: ${{ inputs.postgres_password }}
+          POSTGRES_DB: ${{ inputs.postgres_database }}
         ports:
           - 5432:5432
         options: >-


### PR DESCRIPTION
Provide the docker image envvar `POSTGRES_DB` to allow the default creation of a database named something other than the user's name.