### PR TITLE
fix(elastic): set test_command

### DIFF
--- a/.github/workflows/test-integration-elastic.yml
+++ b/.github/workflows/test-integration-elastic.yml
@@ -7,6 +7,11 @@ on:
         description: 'The GitHub/npm token'
         required: true
     inputs:
+      test_command:
+        description: 'The command to run the integration tests'
+        default: 'npm run test:ci'
+        required: false
+        type: string
       elastic_password:
         description: 'The Elastic password'
         default: 'changeme'


### PR DESCRIPTION
Turns out gha will happily run any empty command and codecov won't error on no coverage files found.