### PR TITLE
chore(ECO-265): Make Commonly Used Actions and Workflows Reusable

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -2,9 +2,13 @@ name: Set Version And Publish
 
 inputs:
   version:
+    description: 'The version to set in package.json and publish'
     required: true
+    type: string
   token:
+    description: 'The GitHub/npm token'
     required: true
+    type: string
   working-directory:
     description: 'The path to the directory to run commands'
     required: false

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -5,16 +5,23 @@ inputs:
     required: true
   token:
     required: true
+  working-directory:
+    description: 'The path to the directory to run commands'
+    required: false
+    type: string
+    default: ./
 
 runs:
   using: "composite"
   steps:
     - name: Set Version
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: npm version "${{ inputs.version }}" --no-git-tag-version --no-commit-hooks
 
     - name: Publish
-      run: npm publish
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ inputs.token }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,7 +2,9 @@ name: Setup Runtime and Dependencies
 
 inputs:
   token:
+    description: 'The GitHub/npm token'
     required: true
+    type: string
   working-directory:
     description: 'The path to the directory to run commands'
     required: false

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,30 +3,38 @@ name: Setup Runtime and Dependencies
 inputs:
   token:
     required: true
+  working-directory:
+    description: 'The path to the directory to run commands'
+    required: false
+    type: string
+    default: ./
 
 runs:
   using: "composite"
   steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Setup node 18
       uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: 18
         registry-url: https://npm.pkg.github.com/
         scope: '@openphone'
-
-    - name: Checkout
-      uses: actions/checkout@v3
 
     - name: Cache dependencies
       id: cache
       uses: actions/cache@v3
+      env:
+        lockfile-path: ${{inputs.working-directory}}/package-lock.json
       with:
-        path: ./node_modules
-        key: modules-${{ hashFiles('package-lock.json') }}
+        path: ${{inputs.working-directory}}/node_modules/
+        key: modules-${{hashFiles(format('{0}/package-lock.json', inputs.working-directory))}}
 
     - name: Run CI
       if: steps.cache.outputs.cache-hit != 'true'
       run: npm ci
+      working-directory: ${{inputs.working-directory}}
       shell: bash
       env:
         NODE_AUTH_TOKEN: ${{inputs.token}}

--- a/.github/workflows/build-and-publish-typescript-project-client.yml
+++ b/.github/workflows/build-and-publish-typescript-project-client.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npm node .
+        run: npm run test
 
       - name: Publish
         uses: OpenPhone/gha/.github/actions/publish@v4

--- a/.github/workflows/build-and-publish-typescript-project-client.yml
+++ b/.github/workflows/build-and-publish-typescript-project-client.yml
@@ -16,14 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: getver
     if: github.event_name == 'push'
+    env:
+      working-directory: ./client
     defaults:
       run:
-        working-directory: ./client
+        working-directory: ${{env.working-directory}}
     steps:
       - name: Setup
         uses: OpenPhone/gha/.github/actions/setup@v4
         with:
           token: ${{ secrets.token }}
+          working-directory: ${{env.working-directory}}
 
       - name: Lint
         run: npm run lint
@@ -39,3 +42,4 @@ jobs:
         with:
           token: ${{ inputs.token }}
           version: ${{ needs.getver.outputs.version }}
+          working-directory: ${{env.working-directory}}

--- a/.github/workflows/build-and-publish-typescript-project-client.yml
+++ b/.github/workflows/build-and-publish-typescript-project-client.yml
@@ -13,7 +13,7 @@ jobs:
 
   build-client:
     name: Build and Publish Client
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: getver
     if: github.event_name == 'push'
     defaults:

--- a/.github/workflows/build-and-publish-typescript-project-client.yml
+++ b/.github/workflows/build-and-publish-typescript-project-client.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Publish
         uses: OpenPhone/gha/.github/actions/publish@v4
         with:
-          token: ${{ inputs.token }}
+          token: ${{ secrets.token }}
           version: ${{ needs.getver.outputs.version }}
           working-directory: ${{env.working-directory}}

--- a/.github/workflows/build-and-publish-typescript-project-types.yml
+++ b/.github/workflows/build-and-publish-typescript-project-types.yml
@@ -37,6 +37,6 @@ jobs:
       - name: Publish
         uses: OpenPhone/gha/.github/actions/publish@v4
         with:
-          token: ${{ inputs.token }}
+          token: ${{ secrets.token }}
           version: ${{ needs.getver.outputs.version }}
           working-directory: ${{env.working-directory}}

--- a/.github/workflows/build-and-publish-typescript-project-types.yml
+++ b/.github/workflows/build-and-publish-typescript-project-types.yml
@@ -13,7 +13,7 @@ jobs:
 
   build-types:
     name: Build and Publish Types
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: getver
     if: github.event_name == 'push'
     defaults:

--- a/.github/workflows/build-and-publish-typescript-project-types.yml
+++ b/.github/workflows/build-and-publish-typescript-project-types.yml
@@ -16,14 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: getver
     if: github.event_name == 'push'
+    env:
+      working-directory: ./types
     defaults:
       run:
-        working-directory: ./types
+        working-directory: ${{env.working-directory}}
     steps:
       - name: Setup
         uses: OpenPhone/gha/.github/actions/setup@v4
         with:
           token: ${{ secrets.token }}
+          working-directory: ${{env.working-directory}}
 
       - name: Build
         run: npm run build
@@ -36,3 +39,4 @@ jobs:
         with:
           token: ${{ inputs.token }}
           version: ${{ needs.getver.outputs.version }}
+          working-directory: ${{env.working-directory}}

--- a/.github/workflows/build-and-publish-typescript-project-types.yml
+++ b/.github/workflows/build-and-publish-typescript-project-types.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npm node .
+        run: npm run test
 
       - name: Publish
         uses: OpenPhone/gha/.github/actions/publish@v4

--- a/.github/workflows/build-and-publish-typescript-project.yml
+++ b/.github/workflows/build-and-publish-typescript-project.yml
@@ -43,6 +43,6 @@ jobs:
       - name: Publish
         uses: OpenPhone/gha/.github/actions/publish@v4
         with:
-          token: ${{ inputs.token }}
+          token: ${{ secrets.token }}
           version: ${{ needs.getver.outputs.version }}
           working-directory: ${{env.working-directory}}

--- a/.github/workflows/build-and-publish-typescript-project.yml
+++ b/.github/workflows/build-and-publish-typescript-project.yml
@@ -16,11 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: getver
     if: github.event_name == 'push'
+    env:
+      working-directory: ./
+    defaults:
+      run:
+        working-directory: ${{env.working-directory}}
     steps:
       - name: Setup
         uses: OpenPhone/gha/.github/actions/setup@v4
         with:
           token: ${{ secrets.token }}
+          working-directory: ${{env.working-directory}}
 
       - name: Lint
         run: npm run lint
@@ -39,3 +45,4 @@ jobs:
         with:
           token: ${{ inputs.token }}
           version: ${{ needs.getver.outputs.version }}
+          working-directory: ${{env.working-directory}}

--- a/.github/workflows/build-and-publish-typescript-project.yml
+++ b/.github/workflows/build-and-publish-typescript-project.yml
@@ -13,7 +13,7 @@ jobs:
 
   build:
     name: Build and Publish Types
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: getver
     if: github.event_name == 'push'
     steps:

--- a/.github/workflows/build-typescript-project-client.yml
+++ b/.github/workflows/build-typescript-project-client.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   build-client:
     name: Build Client
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./client
     defaults:
       run:
         working-directory: ./client

--- a/.github/workflows/build-typescript-project-client.yml
+++ b/.github/workflows/build-typescript-project-client.yml
@@ -15,12 +15,13 @@ jobs:
       working-directory: ./client
     defaults:
       run:
-        working-directory: ./client
+        working-directory: ${{env.working-directory}}
     steps:
       - name: Setup
         uses: OpenPhone/gha/.github/actions/setup@v4
         with:
           token: ${{ secrets.token }}
+          working-directory: ${{env.working-directory}}
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/build-typescript-project-client.yml
+++ b/.github/workflows/build-typescript-project-client.yml
@@ -30,4 +30,4 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npm node .
+        run: npm run test

--- a/.github/workflows/build-typescript-project-types.yml
+++ b/.github/workflows/build-typescript-project-types.yml
@@ -27,4 +27,4 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npm node .
+        run: npm run test

--- a/.github/workflows/build-typescript-project-types.yml
+++ b/.github/workflows/build-typescript-project-types.yml
@@ -10,15 +10,18 @@ on:
 jobs:
   build-types:
     name: Build Types
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./types
     defaults:
       run:
-        working-directory: ./types
+        working-directory: ${{env.working-directory}}
     steps:
       - name: Setup
         uses: OpenPhone/gha/.github/actions/setup@v4
         with:
           token: ${{ secrets.token }}
+          working-directory: ${{env.working-directory}}
 
       - name: Build
         run: npm run build

--- a/.github/workflows/build-typescript-project.yml
+++ b/.github/workflows/build-typescript-project.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup
         uses: OpenPhone/gha/.github/actions/setup@v4

--- a/.github/workflows/build-typescript-project.yml
+++ b/.github/workflows/build-typescript-project.yml
@@ -11,11 +11,17 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      working-directory: ./
+    defaults:
+      run:
+        working-directory: ${{env.working-directory}}
     steps:
       - name: Setup
         uses: OpenPhone/gha/.github/actions/setup@v4
         with:
           token: ${{ secrets.token }}
+          working-directory: ${{env.working-directory}}
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/getsha.yml
+++ b/.github/workflows/getsha.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   getsha:
     name: Get SHA
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     outputs:
       sha: ${{ steps.getsha.outputs.sha }}

--- a/.github/workflows/getsha.yml
+++ b/.github/workflows/getsha.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
     outputs:
       sha:
+        description: 'The GitHub SHA'
         value: ${{ jobs.getsha.outputs.sha }}
 
 jobs:
@@ -14,7 +15,10 @@ jobs:
     outputs:
       sha: ${{ steps.getsha.outputs.sha }}
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - id: getsha
-        shell: bash
         run: echo "sha=${GITHUB_SHA::8}" >> $GITHUB_OUTPUT

--- a/.github/workflows/getver.yml
+++ b/.github/workflows/getver.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   getver:
     name: Get Version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     outputs:
       version: ${{ steps.vertag.outputs.version }}

--- a/.github/workflows/getver.yml
+++ b/.github/workflows/getver.yml
@@ -4,7 +4,8 @@ on:
   workflow_call:
     outputs:
       version:
-        value: ${{ jobs.getver.outputs.version }}
+        description: 'The version of the current tag'
+        value: ${{jobs.getver.outputs.version}}
 
 jobs:
   getver:
@@ -12,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      version: ${{ steps.vertag.outputs.version }}
+      version: ${{steps.vertag.outputs.version}}
 
     steps:
       - id: vertag
-        shell: bash
         if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
         run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-integration-elastic.yml
+++ b/.github/workflows/test-integration-elastic.yml
@@ -22,6 +22,11 @@ on:
         default: 'http://localhost:9200'
         required: false
         type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
 
 jobs:
   test-integration-elastic:
@@ -44,22 +49,11 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
         with:
-          node-version: '18'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@openphone'
-          cache: 'npm'
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: ./node_modules
-          key: modules-${{ hashFiles('package-lock.json') }}
-      - run: npm ci
-        if: steps.cache.outputs.cache-hit != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       - run: npm run elastic:up
         env:
           ELASTIC_URL: ${{ inputs.elastic_url }}

--- a/.github/workflows/test-integration-elastic.yml
+++ b/.github/workflows/test-integration-elastic.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   test-integration-elastic:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     services:
       elasticsearch:

--- a/.github/workflows/test-integration-elastic.yml
+++ b/.github/workflows/test-integration-elastic.yml
@@ -22,11 +22,6 @@ on:
         default: 'http://localhost:9200'
         required: false
         type: string
-      postgres_host:
-        description: 'The Postgres host'
-        default: 'localhost'
-        required: false
-        type: string
       working-directory:
         description: 'The path to the directory to run commands'
         required: false
@@ -66,7 +61,6 @@ jobs:
       - run: ${{ inputs.test_command }} # Test all the things!!!
         env:
           ENVIRONMENT: test
-          POSTGRES_HOST: ${{ inputs.postgres_host }}
           ELASTIC_URL: ${{ inputs.elastic_url }}
           ELASTIC_PASSWORD: ${{ inputs.elastic_password }}
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/test-integration-elastic.yml
+++ b/.github/workflows/test-integration-elastic.yml
@@ -22,6 +22,11 @@ on:
         default: 'http://localhost:9200'
         required: false
         type: string
+      postgres_host:
+        description: 'The Postgres host'
+        default: 'localhost'
+        required: false
+        type: string
       working-directory:
         description: 'The path to the directory to run commands'
         required: false

--- a/.github/workflows/test-integration-mongo.yml
+++ b/.github/workflows/test-integration-mongo.yml
@@ -32,22 +32,28 @@ on:
         default: 'openphone'
         required: false
         type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
 
 jobs:
   test-integration-mongo:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
+        with:
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       - uses: supercharge/mongodb-github-action@1.7.0
         with:
           mongodb-version: ${{ inputs.mongo_version }}
           mongodb-username: ${{ inputs.mongo_username }}
           mongodb-password: ${{ inputs.mongo_password }}
           mongodb-db: ${{ inputs.mongo_db }}
-      - uses: actions/checkout@v3
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
       - run: ${{ inputs.test_command }}
         env:
           ENVIRONMENT: test

--- a/.github/workflows/test-integration-postgres-mongo-elastic.yml
+++ b/.github/workflows/test-integration-postgres-mongo-elastic.yml
@@ -82,6 +82,11 @@ on:
         default: 'http://localhost:9200'
         required: false
         type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
 
 jobs:
   test-integration-postgres-mongo-elastic:
@@ -118,12 +123,11 @@ jobs:
           --health-retries 10
 
     steps:
-      - name: Setup node 18
-        uses: actions/setup-node@v3
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
         with:
-          node-version: '18'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@openphone'
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       - name: spool up mongo
         uses: supercharge/mongodb-github-action@1.7.0
         with:
@@ -131,10 +135,6 @@ jobs:
           mongodb-username: ${{ inputs.mongo_username }}
           mongodb-password: ${{ inputs.mongo_password }}
           mongodb-db: ${{ inputs.mongo_db }}
-      - uses: actions/checkout@v3
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
       # Setup of the global postgres database.
       - name: actions/checkout@v3 @openphone/database
         uses: actions/checkout@v3

--- a/.github/workflows/test-integration-postgres-mongo-rabbit.yml
+++ b/.github/workflows/test-integration-postgres-mongo-rabbit.yml
@@ -72,7 +72,11 @@ on:
         default: 'openphone'
         required: false
         type: string
-
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
 jobs:
   test-integration-postgres-mongo-rabbit:
     runs-on: ubuntu-latest
@@ -101,12 +105,11 @@ jobs:
           - 15672:15672
 
     steps:
-      - name: Setup node 18
-        uses: actions/setup-node@v3
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
         with:
-          node-version: '18'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@openphone'
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       - name: spool up mongo
         uses: supercharge/mongodb-github-action@1.7.0
         with:
@@ -114,10 +117,6 @@ jobs:
           mongodb-username: ${{ inputs.mongo_username }}
           mongodb-password: ${{ inputs.mongo_password }}
           mongodb-db: ${{ inputs.mongo_db }}
-      - uses: actions/checkout@v3
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
       # Setup of the global postgres database.
       - name: actions/checkout@v3 @openphone/database
         uses: actions/checkout@v3

--- a/.github/workflows/test-integration-postgres-mongo-redis.yml
+++ b/.github/workflows/test-integration-postgres-mongo-redis.yml
@@ -77,6 +77,12 @@ on:
         default: 'openphone'
         required: false
         type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
+
 
 jobs:
   test-integration-postgres-mongo-redis:
@@ -107,12 +113,11 @@ jobs:
           --health-retries 5
 
     steps:
-      - name: Setup node 18
-        uses: actions/setup-node@v3
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
         with:
-          node-version: '18'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@openphone'
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       - name: spool up mongo
         uses: supercharge/mongodb-github-action@1.7.0
         with:
@@ -121,24 +126,6 @@ jobs:
           mongodb-password: ${{ inputs.mongo_password }}
           mongodb-db: ${{ inputs.mongo_db }}
 
-      - uses: actions/checkout@v3
-
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v2
-        with:
-          path: ./node_modules
-          key: modules-${{ hashFiles('package-lock.json') }}
-
-      - name: Run CI
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
-      - name: Run Install
-        run: npm install
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
       # Setup of the global postgres database.
       - name: actions/checkout@v3 @openphone/database
         uses: actions/checkout@v3

--- a/.github/workflows/test-integration-postgres-mongo.yml
+++ b/.github/workflows/test-integration-postgres-mongo.yml
@@ -72,6 +72,11 @@ on:
         default: 'openphone'
         required: false
         type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
 
 jobs:
   test-integration-postgres-mongo:
@@ -93,12 +98,11 @@ jobs:
           --health-retries 5
 
     steps:
-      - name: Setup node 18
-        uses: actions/setup-node@v3
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
         with:
-          node-version: '18'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@openphone'
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       - name: spool up mongo
         uses: supercharge/mongodb-github-action@1.7.0
         with:
@@ -106,10 +110,6 @@ jobs:
           mongodb-username: ${{ inputs.mongo_username }}
           mongodb-password: ${{ inputs.mongo_password }}
           mongodb-db: ${{ inputs.mongo_db }}
-      - uses: actions/checkout@v3
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
       # Setup of the global postgres database.
       - name: actions/checkout@v3 @openphone/database
         uses: actions/checkout@v3

--- a/.github/workflows/test-integration-postgres-redis-rabbit.yml
+++ b/.github/workflows/test-integration-postgres-redis-rabbit.yml
@@ -17,6 +17,11 @@ on:
         default: true
         required: false
         type: boolean
+      global_postgres_ref:
+        description: 'Branch of Postgres @openphone/database repo to use'
+        default: 'master'
+        required: false
+        type: string
       migration_command:
         description: 'The command to run the Postgres migrations'
         default: 'npm run db:up'

--- a/.github/workflows/test-integration-postgres-redis-rabbit.yml
+++ b/.github/workflows/test-integration-postgres-redis-rabbit.yml
@@ -52,6 +52,11 @@ on:
         default: 'openphone'
         required: false
         type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
 
 jobs:
   test-integration-postgres-rabbit-redis:
@@ -89,16 +94,11 @@ jobs:
           - 5672:5672
           - 15672:15672
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup node 18
-        uses: actions/setup-node@v3
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
         with:
-          node-version: '18'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@openphone'
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       # Setup of the global postgres database.
       - name: actions/checkout@v3 @openphone/database
         uses: actions/checkout@v3

--- a/.github/workflows/test-integration-postgres.yml
+++ b/.github/workflows/test-integration-postgres.yml
@@ -52,6 +52,11 @@ on:
         default: 'openphone'
         required: false
         type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
 
 jobs:
   test-integration-postgres:
@@ -73,16 +78,11 @@ jobs:
           --health-retries 5
 
     steps:
-      - name: Setup node 18
-        uses: actions/setup-node@v3
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
         with:
-          node-version: '18'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@openphone'
-      - uses: actions/checkout@v3
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.token}}
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       # Setup of the global postgres database.
       - name: actions/checkout@v3 @openphone/database
         uses: actions/checkout@v3

--- a/.github/workflows/test-integration-rabbit-redis.yml
+++ b/.github/workflows/test-integration-rabbit-redis.yml
@@ -12,6 +12,11 @@ on:
         default: 'npm run test:ci'
         required: false
         type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
 
 jobs:
   test-integration-rabbit-redis:
@@ -37,16 +42,11 @@ jobs:
           - 15672:15672
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup node 18
-        uses: actions/setup-node@v3
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
         with:
-          node-version: '18'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@openphone'
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       - run: ${{ inputs.test_command }}
         env:
           ENVIRONMENT: test

--- a/.github/workflows/test-integration-rabbit.yml
+++ b/.github/workflows/test-integration-rabbit.yml
@@ -12,6 +12,11 @@ on:
         default: 'npm run test:ci'
         required: false
         type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
 
 jobs:
   test-integration-rabbit:
@@ -28,16 +33,11 @@ jobs:
           - 15672:15672
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup node 18
-        uses: actions/setup-node@v3
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
         with:
-          node-version: '18'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@openphone'
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       - run: ${{ inputs.test_command }}
         env:
           ENVIRONMENT: test

--- a/.github/workflows/test-integration-redis.yml
+++ b/.github/workflows/test-integration-redis.yml
@@ -12,6 +12,11 @@ on:
         default: 'npm run test:ci'
         required: false
         type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
 
 jobs:
   test-integration-redis:
@@ -29,16 +34,11 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup node 18
-        uses: actions/setup-node@v3
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
         with:
-          node-version: '18'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@openphone'
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       - run: ${{ inputs.test_command }}
         env:
           ENVIRONMENT: test

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -12,22 +12,22 @@ on:
         default: 'npm run test:ci'
         required: false
         type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
 
 jobs:
   test-integration:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup node 18
-        uses: actions/setup-node@v3
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v4
         with:
-          node-version: '18'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@openphone'
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.token }}
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
       - run: ${{ inputs.test_command }}
         env:
           ENVIRONMENT: test


### PR DESCRIPTION
- allows composite actions to be run in subdirs for client and types
- updates exiting testing workflows to use new setup action (which give us consistent caching)
- adds some missing parameters to existing workflows (b1367d4)
- fixes publishing to get token from secrets (68f76dd)
- fixes script to run 'tests' on client and types (860386c)
- consolidates setting of node version to one action