### PR TITLE
chore: update pr-labeler-action to v4

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -17,7 +17,7 @@ jobs:
   label-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: TimonVS/pr-labeler-action@v3
+      - uses: TimonVS/pr-labeler-action@v4
         with:
           configuration-path: ${{ inputs.configuration-path }}
         env:


### PR DESCRIPTION
This should remove the warning in projects that use this workflow (e.g. Communication)
![image](https://github.com/OpenPhone/gha/assets/115495150/c8dc1b1a-9359-4d97-a72b-1a32b984c390)
