### PR TITLE
perf: no fetch-depth: 0

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -52,8 +52,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Update json
         if: ${{ inputs.update_json }}
         run: |

--- a/.github/workflows/helm-deploy-eks.yml
+++ b/.github/workflows/helm-deploy-eks.yml
@@ -74,7 +74,6 @@ jobs:
         with:
           repository: ${{ secrets.chart_repo }}
           path: ${{ secrets.checkout_path }}
-          fetch-depth: 0
           token: ${{ secrets.token }}
       - name: Setup kubeconfig
         env:

--- a/.github/workflows/kubectl-deploy-job-eks.yml
+++ b/.github/workflows/kubectl-deploy-job-eks.yml
@@ -60,8 +60,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Setup kubeconfig
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
@@ -70,7 +68,7 @@ jobs:
           aws eks --region ${{ secrets.aws_default_region }} \
           update-kubeconfig --name ${{ secrets.clustername }}
       - name: kubectl apply
-        env: 
+        env:
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           registry: ${{ inputs.registry }}${{ inputs.registry_path}}

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Lint Code Base
         uses: github/super-linter@v4
         env:


### PR DESCRIPTION
At present we're opting into [Set fetch-depth: 0 to fetch all history for all branches and tags.](https://github.com/actions/checkout). Though we are better about not letting branches linger in the repos.

I know I've made this edit other workflows. Don't see any difference in these.

Noticed this in the database migration job:
<img width="892" alt="image" src="https://github.com/OpenPhone/gha/assets/29136191/dccc2436-377c-4983-9b78-cc024489fab9">


