### PR TITLE
cache the npm cache, rather than installed modules

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,11 +30,10 @@ runs:
       env:
         lockfile-path: ${{inputs.working-directory}}/package-lock.json
       with:
-        path: ${{inputs.working-directory}}/node_modules/
+        path: ~/.npm
         key: modules-${{hashFiles(format('{0}/package-lock.json', inputs.working-directory))}}
 
     - name: Run CI
-      if: steps.cache.outputs.cache-hit != 'true'
       run: npm ci
       working-directory: ${{inputs.working-directory}}
       shell: bash


### PR DESCRIPTION
This makes it so that the `actions/cache` stores/restores the npm cache, rather than the final installed output. This prevents it from having to download all of the tarballs from npm, but will still allow tools like `prisma` to perform additional modifications inside of `node_modules`. It's also arguably safer for modules with a compiled component, because it would be portable if we ever change the `runs-on: ubuntu-latest` to some other architecture.