### PR TITLE
add helm namespace input to helm-deploy-eks.yml

### DIFF
--- a/.github/workflows/helm-deploy-eks.yml
+++ b/.github/workflows/helm-deploy-eks.yml
@@ -4,65 +4,65 @@ on:
   workflow_call:
     secrets:
       token:
-        description: 'Token for pulling repo with charts'
+        description: "Token for pulling repo with charts"
         required: true
       aws_access_key_id:
-        description: 'AWS_ACCESS_KEY_ID'
+        description: "AWS_ACCESS_KEY_ID"
         required: true
       aws_secret_access_key:
-        description: 'AWS_SECRET_ACCESS_KEY'
+        description: "AWS_SECRET_ACCESS_KEY"
         required: true
       aws_default_region:
-        description: 'AWS_DEFAULT_REGION'
+        description: "AWS_DEFAULT_REGION"
         required: true
       chart_repo:
-        description: 'Repository container helm charts'
+        description: "Repository container helm charts"
         required: true
       checkout_path:
-        description: 'Checkout path for helm charts repo'
+        description: "Checkout path for helm charts repo"
         required: true
       clustername:
-        description: 'Cluster Name'
+        description: "Cluster Name"
         required: true
     inputs:
       tag:
-        description: 'Tag for docker image to deploy'
+        description: "Tag for docker image to deploy"
         required: false
         type: string
-        default: 'latest'
+        default: "latest"
       target_url:
-        description: 'Target URL for deploy'
+        description: "Target URL for deploy"
         required: true
         type: string
       chart_name:
-        description: 'Chart name in the repo'
+        description: "Chart name in the repo"
         required: true
         type: string
       chart_dir:
-        description: 'Folder where the chart is including checkout path'
+        description: "Folder where the chart is including checkout path"
         required: true
         type: string
       release_name:
-        description: 'release name for the chart'
+        description: "release name for the chart"
         required: true
         type: string
       values_file:
-        description: 'values.yml file to use'
+        description: "values.yml file to use"
         required: true
         type: string
       values_extra:
-        description: 'extra values for --set'
+        description: "extra values for --set"
         required: false
         type: string
       deploy_env:
-        description: 'Environment for deployment'
+        description: "Environment for deployment"
         required: true
         type: string
       timeout:
-        description: 'Duration to wait for a successful deployment e.g. 300s, 10m, 1h'
+        description: "Duration to wait for a successful deployment e.g. 300s, 10m, 1h"
         required: false
         type: string
-        default: '300s'
+        default: "300s"
 
 jobs:
   deploy-helm:

--- a/.github/workflows/helm-deploy-eks.yml
+++ b/.github/workflows/helm-deploy-eks.yml
@@ -63,6 +63,11 @@ on:
         required: false
         type: string
         default: "300s"
+      helm_namespace:
+        description: "Namespace for helm deployment"
+        required: false
+        type: string
+        default: "default"
 
 jobs:
   deploy-helm:
@@ -92,7 +97,7 @@ jobs:
           environment: ${{ inputs.deploy_env }}
       - name: Form helm command
         run: |
-          cmd="helm upgrade --install --atomic ${{ inputs.chart_name }} ./ -f ${{ inputs.values_file }} --wait --timeout ${{ inputs.timeout }}"
+          cmd="helm upgrade --install --atomic ${{ inputs.chart_name }} ./ -f ${{ inputs.values_file }} --wait --timeout ${{ inputs.timeout }} --namespace ${{ inputs.helm_namespace }}"
           IFS="," read -a extraval <<< "${{ inputs.values_extra }}"
           for i in "${extraval[@]}"; do
               echo "Adding set command for ${i}"


### PR DESCRIPTION
## Description

As part of adding `etcd` to our cluster. We need to be able to specify namespaces when running `helm upgrade --install`
This is backwards compatible since the default still defaults to `"default"` 