### PR TITLE
feat(integration-tests): create file for running integration tests in a matrix

### DIFF
--- a/.github/workflows/test-integration-postgres-redis-rabbit-matrix.yml
+++ b/.github/workflows/test-integration-postgres-redis-rabbit-matrix.yml
@@ -1,0 +1,152 @@
+name: Reusable workflow for running postgres with rabbit and redis integration tests in a Github Matrix
+
+on:
+  workflow_call:
+    secrets:
+      token:
+        description: 'The GitHub/npm token'
+        required: true
+    inputs:
+      test_command:
+        description: 'The command to run the integration tests'
+        default: 'npm run test:ci'
+        required: false
+        type: string
+      setup_global_postgres:
+        description: 'Setup Postgres @openphone/database repo'
+        default: true
+        required: false
+        type: boolean
+      global_postgres_ref:
+        description: 'Branch of Postgres @openphone/database repo to use'
+        default: 'master'
+        required: false
+        type: string
+      migration_command:
+        description: 'The command to run the Postgres migrations'
+        default: 'npm run db:up'
+        required: false
+        type: string
+      skip_migration:
+        description: 'Whether or not the migrations should be skipped. Useful for when you want to run specific migration tests'
+        default: false
+        required: false
+        type: boolean
+      postgres_version:
+        description: 'The version of Postgres to use'
+        default: '13'
+        required: false
+        type: string
+      postgres_user:
+        description: 'The Postgres user'
+        default: 'openphone'
+        required: false
+        type: string
+      postgres_password:
+        description: 'The Postgres password'
+        default: 'docker'
+        required: false
+        type: string
+      postgres_host:
+        description: 'The Postgres host'
+        default: 'localhost'
+        required: false
+        type: string
+      postgres_database:
+        description: 'The Postgres database'
+        default: 'openphone'
+        required: false
+        type: string
+      working-directory:
+        description: 'The path to the directory to run commands'
+        required: false
+        type: string
+        default: ./
+      timeout-minutes:
+        description: 'The max time to allow the action to run'
+        required: false
+        type: number
+        default: 10
+
+jobs:
+  test-integration-postgres-rabbit-redis-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+
+    services:
+      postgres-svc:
+        image: postgres:13
+        env:
+          POSTGRES_USER: ${{ inputs.postgres_user }}
+          POSTGRES_PASSWORD: ${{ inputs.postgres_password }}
+          POSTGRES_DB: ${{ inputs.postgres_database }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis-svc:
+        image: redislabs/rejson:latest
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      rabbitmq:
+        image: rabbitmq:3.9.7-management
+        env:
+          RABBITMQ_DEFAULT_USER: openphone
+          RABBITMQ_DEFAULT_PASS: docker
+        ports:
+          - 5672:5672
+          - 15672:15672
+    strategy:
+      matrix:
+        shard: [ 1, 2, 3, 4 ]
+    steps:
+      - name: Setup
+        uses: OpenPhone/gha/.github/actions/setup@v5
+        with:
+          token: ${{ secrets.token }}
+          working-directory: ${{inputs.working-directory}}
+      # Setup of the global postgres database.
+      - name: actions/checkout@v3 @openphone/database
+        uses: actions/checkout@v3
+        if: ${{ inputs.setup_global_postgres && !inputs.skip_migration }}
+        with:
+          repository: 'OpenPhone/database'
+          ref: ${{ inputs.global_postgres_ref }}
+          path: 'database'
+          token: ${{ secrets.token }}
+
+      - name: migrate global postgres database
+        run: |
+          npm ci
+          npm run up
+        if: ${{ inputs.setup_global_postgres && !inputs.skip_migration }}
+        working-directory: 'database'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.token }}
+          ENVIRONMENT: localdev
+          POSTGRES_HOST: ${{ inputs.postgres_host }}
+      # Run migrations against the local postgres database.
+      - name: Migrate Voice Database
+        run: ${{ inputs.migration_command }}
+        if: ${{ !inputs.setup_global_postgres && !inputs.skip_migration }}
+        env:
+          ENVIRONMENT: test
+          POSTGRES_HOST: ${{ inputs.postgres_host }}
+      # Test all the things!!!
+      - name: Run Integration Tests
+        run: ${{ inputs.test_command }} -- -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        env:
+          ENVIRONMENT: test
+          POSTGRES_HOST: ${{ inputs.postgres_host }}
+      - name: Codecov Uploader
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage/coverage-final.json


### PR DESCRIPTION
I copy/pasted the `test-integration-postgres-redis-rabbit.yml` workflow into a new file and added support for using a Github matrix.

Codecov automatically merges all coverage reports for a commit so we don't have to do anything special to report coverage.