### PR TITLE
Remove the call to 'node .'

### DIFF
--- a/.github/workflows/build-and-publish-typescript-project.yml
+++ b/.github/workflows/build-and-publish-typescript-project.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Run
-        run: node .
-
       - name: Publish
         uses: OpenPhone/gha/.github/actions/publish@v5
         with:

--- a/.github/workflows/build-typescript-project.yml
+++ b/.github/workflows/build-typescript-project.yml
@@ -31,6 +31,3 @@ jobs:
 
       - name: Build
         run: npm run build
-
-      - name: Run
-        run: node .


### PR DESCRIPTION
Tests should import all of this anyway, and loading the index file directly runs into issues with validated `config.ts` values